### PR TITLE
PRO-1492: Fix hex and grid with log scale

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -2,7 +2,7 @@
   "name": "@pro/deck.gl-aggregation-layers",
   "description": "deck.gl layers that aggregate the input data into alternative representations",
   "license": "MIT",
-  "version": "8.8.17-log.0",
+  "version": "8.8.17-2gis.2",
   "publishConfig": {
     "access": "public"
   },

--- a/modules/aggregation-layers/src/utils/scale-utils.js
+++ b/modules/aggregation-layers/src/utils/scale-utils.js
@@ -150,15 +150,15 @@ export function quantizeScale(domain, range, value) {
 
 // Logarithmic scale with base 10
 export function logScale(domain, range, value) {
-  if (domain[1] - domain[0] <= 0 || domain[0] === 0) {
+  if (domain[1] - domain[0] <= 0) {
     log.warn('logScale: invalid domain, returning range[0]')();
     return range[0];
   }
 
-  const step = Math.log10(domain[1] / domain[0]) / (range.length - 1);
-  const idx = Math.floor(Math.log10(value / domain[0]) / step);
+  const minValue = domain[0] > 0 ? domain[0] : 1;
+  const step = Math.log10(domain[1] / minValue) / range.length;
+  const idx = Math.floor(Math.log10(value / minValue) / step);
   const clampIdx = Math.max(Math.min(idx, range.length - 1), 0);
-
   return range[clampIdx];
 }
 


### PR DESCRIPTION
Сделано 2 фикса:
- Синхронизировано вычисление логарифма с функцией `scaleLog` из d3.
- Добавлен обход проблемы с 0 у диапазона значений. Это временное решение, в будущем надо решить как нормализовывать диапазоны.