### PR TITLE
Speed up grid aggregator

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -2,7 +2,7 @@
   "name": "@pro/deck.gl-aggregation-layers",
   "description": "deck.gl layers that aggregate the input data into alternative representations",
   "license": "MIT",
-  "version": "8.8.17-2gis.2",
+  "version": "8.8.17-2gis.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Ускорил агрегацию гексов засчет:
1. Прохода по всему массиву данных 1 раз, вместо 2. Раньше вначале вызывалась функция pointsToGridHashing, а потом getGridLayerDataFromGridHash, хотя их результат можно объединить.
2. Использования чисел в качестве ключа хэша сетки, вместо строк. На таком количестве данных становится заметно, что создание и конкатенация строк работает медленнее, чем банальное умножение 2 чисел.

Точно посчитать величину ускорения сложно, но примерно раза в 2. К сожалению, это все равно много и фриз заметен юзером.

В мастере сейчас так:
![image](https://user-images.githubusercontent.com/3996552/209323437-641c051e-0961-4966-9ee1-e645a9224d44.png)

В ветке так:
![image](https://user-images.githubusercontent.com/3996552/209323481-f28d3e0f-a722-48a7-b721-3b9067bf71e4.png)

В апстрим это изменение пока тащить не хочется, потому что:
1. Мне пришлось удалить использование какого-то `posOffset`. Мы его точно не используем, точно ли он нужен я не уверен, а разбираться долго.
2. Для мержа придется дополнять их перф тесты, на что сейчас тоже тратить время не хочется.