### PR TITLE
Add log to types

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -2,7 +2,7 @@
   "name": "@pro/deck.gl-aggregation-layers",
   "description": "deck.gl layers that aggregate the input data into alternative representations",
   "license": "MIT",
-  "version": "8.8.17-2gis.4",
+  "version": "8.8.17-2gis.5",
   "publishConfig": {
     "access": "public"
   },

--- a/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
@@ -158,7 +158,7 @@ export type _CPUGridLayerProps<DataT> = {
    * Supported Values are 'quantize', 'linear', 'quantile' and 'ordinal'.
    * @default 'quantize'
    */
-  colorScaleType?: 'quantize' | 'linear' | 'quantile' | 'ordinal';
+  colorScaleType?: 'quantize' | 'linear' | 'quantile' | 'ordinal' | 'log';
 
   /**
    * Scaling function used to determine the elevation of the grid cell, only supports 'linear'.

--- a/modules/aggregation-layers/src/grid-layer/grid-layer.ts
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer.ts
@@ -101,7 +101,7 @@ export default class GridLayer<DataT = any, ExtraPropsT = {}> extends CompositeL
       // accessor for custom color or elevation calculation is specified
       return false;
     }
-    if (colorScaleType === 'quantile' || colorScaleType === 'ordinal') {
+    if (colorScaleType === 'quantile' || colorScaleType === 'ordinal' || colorScaleType === 'log') {
       // quantile and ordinal scales are not supported on GPU
       return false;
     }

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
@@ -171,7 +171,7 @@ type _HexagonLayerProps<DataT = any> = {
    * Supported Values are 'quantize', 'quantile' and 'ordinal'.
    * @default 'quantize'
    */
-  colorScaleType?: 'quantize' | 'quantile' | 'ordinal';
+  colorScaleType?: 'quantize' | 'quantile' | 'ordinal' | 'log';
 
   /**
    * Scaling function used to determine the elevation of the grid cell, only supports 'linear'.


### PR DESCRIPTION
Прокинул `log` в типы, видимо, мы где-то потеряли их.